### PR TITLE
source/cmake: use old source tag of STM32CubeMP1 firmware

### DIFF
--- a/source/cmake/bsp-disco.cmake
+++ b/source/cmake/bsp-disco.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 
 FetchContent_Declare(STM32CubeMP1
     GIT_REPOSITORY  https://github.com/STMicroelectronics/STM32CubeMP1.git
-    GIT_TAG         master
+    GIT_TAG         1.4.0
 )
 FetchContent_GetProperties(stm32cubemp1)
 if(NOT stm32cubemp1_POPULATED)

--- a/source/cmake/hal_drivers.cmake
+++ b/source/cmake/hal_drivers.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 
 FetchContent_Declare(STM32CubeMP1
     GIT_REPOSITORY  https://github.com/STMicroelectronics/STM32CubeMP1.git
-    GIT_TAG         master
+    GIT_TAG         1.4.0
 )
 FetchContent_GetProperties(stm32cubemp1)
 if(NOT stm32cubemp1_POPULATED)

--- a/source/cmake/ll_drivers.cmake
+++ b/source/cmake/ll_drivers.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 
 FetchContent_Declare(STM32CubeMP1
     GIT_REPOSITORY  https://github.com/STMicroelectronics/STM32CubeMP1.git
-    GIT_TAG         master
+    GIT_TAG         1.4.0
 )
 FetchContent_GetProperties(stm32cubemp1)
 if(NOT stm32cubemp1_POPULATED)

--- a/source/cmake/openamp.cmake
+++ b/source/cmake/openamp.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 
 FetchContent_Declare(STM32CubeMP1
     GIT_REPOSITORY  https://github.com/STMicroelectronics/STM32CubeMP1.git
-    GIT_TAG         master
+    GIT_TAG         1.4.0
 )
 FetchContent_GetProperties(stm32cubemp1)
 if(NOT stm32cubemp1_POPULATED)


### PR DESCRIPTION
The source code cannot be built with latest STM32CubeMP1 firmware package. So, it is modified to use proper version of STM32CubeMP1 firmware package.